### PR TITLE
Automatically detect the distro of builder

### DIFF
--- a/.github/workflows/selftest.yml
+++ b/.github/workflows/selftest.yml
@@ -6,7 +6,14 @@ jobs:
   selftest:
     name: Self-test
     runs-on: ubuntu-latest
-    container: quay.io/ovirt/buildcontainer:stream8
+    container: quay.io/ovirt/buildcontainer:${{ matrix.tag }}
+    strategy:
+      matrix:
+        include:
+          - tag: el8stream
+            rpm-suffix: el8
+          - tag: el9stream
+            rpm-suffix: el9
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -23,11 +30,10 @@ jobs:
         uses: ./
         with:
           directory: test-artifacts
-          distro: el8stream
       - name: Download artifacts
         uses: actions/download-artifact@v2
         with:
-          name: artifacts-el8stream
+          name: rpm-${{ matrix.rpm-suffix }}
           path: downloaded
       - name: Check if the test.rpm is there
         run:

--- a/README.md
+++ b/README.md
@@ -15,11 +15,10 @@ jobs:
   selftest:
     name: Self-test
     runs-on: ubuntu-latest
-    container: quay.io/ovirt/buildcontainer:stream8
+    container: quay.io/ovirt/buildcontainer:el8stream
     steps:
     - name: Upload artifacts
-      uses: ovirt/upload-rpms-action@v1
+      uses: ovirt/upload-rpms-action@v2
       with:
         directory: test-artifacts
-        distro: el8stream
 ```

--- a/action.yml
+++ b/action.yml
@@ -5,21 +5,21 @@ inputs:
     description: 'Which directory to upload'
     required: true
     default: 'exported-artifacts'
-  distro:
-    description: 'The distribution of artifacts'
-    required: true
-    default: 'el8stream'
 runs:
   using: "composite"
   steps:
     - name: Install createrepo_c if needed
       shell: bash
       run: which createrepo_c || dnf install -y createrepo_c
-    - name: Create DNF repository
+    - name: Create DNF repository if needed
       shell: bash
-      run: createrepo_c ${{ inputs.directory }}
+      run: test -d ${{ inputs.directory }}/repodata || createrepo_c ${{ inputs.directory }}
+    - name: Get distro suffix
+      id: eval
+      shell: bash
+      run: echo "::set-output name=distro::$(rpm --eval %{?dist} | cut -d '.' -f 2)"
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: artifacts-${{ inputs.distro }}
+        name: rpm-${{ steps.eval.outputs.distro }}
         path: ${{ inputs.directory }}


### PR DESCRIPTION
Detect the distro of the host/container that the
action is running in and create artifact called
rpm-$DISTRO, e.g. rpm-el8.