### PR TITLE
Rebase on upload-artifact@v4

### DIFF
--- a/.github/workflows/selftest.yml
+++ b/.github/workflows/selftest.yml
@@ -16,7 +16,7 @@ jobs:
             rpm-suffix: el9
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Create sample RPM
         run: |
           set -x
@@ -31,7 +31,7 @@ jobs:
         with:
           directory: test-artifacts
       - name: Download artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: rpm-${{ matrix.rpm-suffix }}
           path: downloaded

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ runs:
       shell: bash
       run: echo "distro=$(rpm --eval %{?dist} | cut -d '.' -f 2)" >> $GITHUB_OUTPUT
     - name: Upload artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: rpm-${{ steps.eval.outputs.distro }}
         path: ${{ inputs.directory }}


### PR DESCRIPTION
Resolves:
```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/upload-artifact@v3.
```